### PR TITLE
Fix build on ppc64 with clang

### DIFF
--- a/src/include/clRNG/private/Random123/features/gccfeatures.h
+++ b/src/include/clRNG/private/Random123/features/gccfeatures.h
@@ -44,7 +44,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  Please let the authors know of any successes (or failures). */
 #endif
 
-#ifdef __powerpc__
+#if defined(__powerpc__) && !defined(__clang__)
 #include <ppu_intrinsics.h>
 #endif
 


### PR DESCRIPTION
clang doesn't have ppu_intrinsics.h.