### PR TITLE
Implement Philox RNG seeding

### DIFF
--- a/src/include/clRNG/philox432.clh
+++ b/src/include/clRNG/philox432.clh
@@ -58,6 +58,7 @@ typedef struct clrngPhilox432Counter_ {
 
 
 typedef struct {
+	cl_uint  key[2];             // 64-bit key
 	clrngPhilox432Counter  ctr;  // 128 bits counter
 	cl_uint  deck[4];            // this table hold the 4x32 generated uint from philox4x32(ctr,kry) function
 	cl_uint deckIndex;           //the index of actual pregenerated integer to give to the user

--- a/src/include/clRNG/philox432.h
+++ b/src/include/clRNG/philox432.h
@@ -60,6 +60,7 @@ typedef struct clrngPhilox432Counter_ {
 
 
 typedef struct {
+	cl_uint  key[2];             // 64-bit key
 	clrngPhilox432Counter  ctr;  // 128 bits counter
 	cl_uint  deck[4];            // this table hold the 4x32 generated uint from philox4x32(ctr,kry) function
 	cl_uint deckIndex;           //the index of actual pregenerated integer to give to the user

--- a/src/include/clRNG/private/philox432.c.h
+++ b/src/include/clRNG/private/philox432.c.h
@@ -86,7 +86,7 @@ clrngStatus clrngPhilox432CopyOverStreams(size_t count, clrngPhilox432Stream* de
 void clrngPhilox432GenerateDeck(clrngPhilox432StreamState *currentState)
 {
 	//Default key
-	philox4x32_key_t k = { { 0, 0 } };
+	philox4x32_key_t k = { { currentState->key[0], currentState->key[1] } };
 
 	//get the currect state
 	philox4x32_ctr_t c = { { 0 } };

--- a/src/library/philox432.c
+++ b/src/library/philox432.c
@@ -55,6 +55,7 @@ struct clrngPhilox432StreamCreator_ {
 */
 
 #define BASE_CREATOR_STATE { \
+        {0, 0}, \
         {{ 0, 0},{ 0, 1}}, \
         { 0, 0, 0, 0 }, \
         0 }
@@ -147,7 +148,7 @@ clrngStatus clrngPhilox432ChangeStreamsSpacing(clrngPhilox432StreamCreator* crea
 
 	//Create Base Creator
 	clrngPhilox432StreamCreator* baseCreator = clrngPhilox432CopyStreamCreator(NULL, NULL);
-	clrngPhilox432StreamState baseState = { { { 0, 0 }, { 0, 0 } },	{ 0, 0, 0, 0 },	0 };
+	clrngPhilox432StreamState baseState = { { 0, 0 }, { { 0, 0 }, { 0, 0 } },	{ 0, 0, 0, 0 },	0 };
 	clrngPhilox432SetBaseCreatorState(baseCreator, &baseState);
 
 	//Create stream


### PR DESCRIPTION
The implementation of the Philox RNG did not support user-provided seeds/keys. This PR implements this

* Added key to ``clrngPhilox432StreamState``
* Updated base creator to set this to zero
* Updated ``clrngPhilox432GenerateDeck`` to use key in ``clrngPhilox432StreamState``