### PR TITLE
Fix compilation bug

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -216,6 +216,8 @@ elseif( CMAKE_COMPILER_IS_GNUCXX )
 	
 	set( CMAKE_CXX_FLAGS "-pthread ${CMAKE_CXX_FLAGS}" )
 	set( CMAKE_C_FLAGS "-std=c11 -Wall -pedantic-errors -pthread ${CMAKE_C_FLAGS}" )
+	set( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-expansion-to-defined" )
+
 	
 	if( BUILD64 )
 		set( CMAKE_CXX_FLAGS "-m64 ${CMAKE_CXX_FLAGS}" )


### PR DESCRIPTION
For newer versions of gcc, -Wexpansion-to-defined throws an error for the header compiler_features.h. I turn of the flag here. (see also : https://bugs.webkit.org/show_bug.cgi?id=172618)