### PR TITLE
Fix change in memory scope bug

### DIFF
--- a/src/include/clRNG/private/mrg31k3p.c.h
+++ b/src/include/clRNG/private/mrg31k3p.c.h
@@ -50,35 +50,6 @@
 #define mrg31k3p_NORM_cl_float  4.6566126e-10
 
 
-
-#if defined(CLRNG_ENABLE_SUBSTREAMS) || !defined(__CLRNG_DEVICE_API)
-
-// clrngMrg31k3p_A1p72 and clrngMrg31k3p_A2p72 jump 2^72 steps forward
-#if defined(__CLRNG_DEVICE_API)
-__constant
-#else
-static
-#endif
-cl_uint clrngMrg31k3p_A1p72[3][3] = { 
-    {1516919229,  758510237, 499121365},
-    {1884998244, 1516919229, 335398200},
-    {601897748,  1884998244, 358115744}
-};
-
-#if defined(__CLRNG_DEVICE_API)
-__constant
-#else
-static
-#endif
-cl_uint clrngMrg31k3p_A2p72[3][3] = { 
-    {1228857673, 1496414766,  954677935},
-    {1133297478, 1407477216, 1496414766},
-    {2002613992, 1639496704, 1407477216}
-};
-
-#endif
-
-
 clrngStatus clrngMrg31k3pCopyOverStreams(size_t count, clrngMrg31k3pStream* destStreams, const clrngMrg31k3pStream* srcStreams)
 {
     //Check params
@@ -226,6 +197,17 @@ clrngStatus clrngMrg31k3pRewindSubstreams(size_t count, clrngMrg31k3pStream* str
 
 clrngStatus clrngMrg31k3pForwardToNextSubstreams(size_t count, clrngMrg31k3pStream* streams)
 {
+	cl_uint __private clrngMrg31k3p_A1p72[3][3] = { 
+	    {1516919229,  758510237, 499121365},
+	    {1884998244, 1516919229, 335398200},
+	    {601897748,  1884998244, 358115744}
+	};
+
+	cl_uint __private clrngMrg31k3p_A2p72[3][3] = { 
+	    {1228857673, 1496414766,  954677935},
+	    {1133297478, 1407477216, 1496414766},
+	    {2002613992, 1639496704, 1407477216}
+	};
 	//Check params
 	if (!streams)
 		return clrngSetErrorString(CLRNG_INVALID_VALUE, "%s(): streams cannot be NULL", __func__);

--- a/src/include/clRNG/private/mrg32k3a.c.h
+++ b/src/include/clRNG/private/mrg32k3a.c.h
@@ -43,34 +43,6 @@
 #define Mrg32k3a_NORM_cl_double 2.328306549295727688e-10
 #define Mrg32k3a_NORM_cl_float  2.3283064e-10
 
-#if defined(CLRNG_ENABLE_SUBSTREAMS) || !defined(__CLRNG_DEVICE_API)
-
-// clrngMrg32k3a_A1p76 and clrngMrg32k3a_A2p76 jump 2^76 steps forward
-#if defined(__CLRNG_DEVICE_API)
-__constant
-#else
-static
-#endif
-cl_ulong clrngMrg32k3a_A1p76[3][3] = {
-	{ 82758667, 1871391091, 4127413238 },
-	{ 3672831523, 69195019, 1871391091 },
-	{ 3672091415, 3528743235, 69195019 }
-};
-
-#if defined(__CLRNG_DEVICE_API)
-__constant
-#else
-static
-#endif
-cl_ulong clrngMrg32k3a_A2p76[3][3] = {
-	{ 1511326704, 3759209742, 1610795712 },
-	{ 4292754251, 1511326704, 3889917532 },
-	{ 3859662829, 4292754251, 3708466080 }
-};
-
-#endif
-
-
 clrngStatus clrngMrg32k3aCopyOverStreams(size_t count, clrngMrg32k3aStream* destStreams, const clrngMrg32k3aStream* srcStreams)
 {
 	//Check params
@@ -205,6 +177,17 @@ clrngStatus clrngMrg32k3aRewindSubstreams(size_t count, clrngMrg32k3aStream* str
 
 clrngStatus clrngMrg32k3aForwardToNextSubstreams(size_t count, clrngMrg32k3aStream* streams)
 {
+	cl_ulong __private clrngMrg32k3a_A1p76[3][3] = {
+		{ 82758667, 1871391091, 4127413238 },
+		{ 3672831523, 69195019, 1871391091 },
+		{ 3672091415, 3528743235, 69195019 }
+	};
+
+	cl_ulong __private clrngMrg32k3a_A2p76[3][3] = {
+		{ 1511326704, 3759209742, 1610795712 },
+		{ 4292754251, 1511326704, 3889917532 },
+		{ 3859662829, 4292754251, 3708466080 }
+	};
 	//Check params
 	if (!streams)
 		return clrngSetErrorString(CLRNG_INVALID_VALUE, "%s(): streams cannot be NULL", __func__);


### PR DESCRIPTION
I get a bug where OpenCL cannot compile CTest kernels.
```
========================================
In file included from 2:3:
In file included from ./include/clRNG/mrg31k3p.clh:155:
./include/clRNG/private/mrg31k3p.c.h:234:14: error: passing '__constant cl_uint (*)[3]' to parameter of type 'cl_uint __private (*)[3]' changes address space of pointer
                modMatVec (clrngMrg31k3p_A1p72, streams[k].substream.g1, streams[k].substream.g1, mrg31k3p_M1);
                           ^~~~~~~~~~~~~~~~~~~
./include/clRNG/./private/modular.c.h:79:44: note: passing argument to parameter 'A' here
static void modMatVec (MODULAR_NUMBER_TYPE A[N][N], MODULAR_NUMBER_TYPE s[N], MODULAR_NUMBER_TYPE v[N], MODULAR_NUMBER_TYPE m)
                                           ^
In file included from 2:3:
In file included from ./include/clRNG/mrg31k3p.clh:155:
./include/clRNG/private/mrg31k3p.c.h:235:14: error: passing '__constant cl_uint (*)[3]' to parameter of type 'cl_uint __private (*)[3]' changes address space of pointer
                modMatVec (clrngMrg31k3p_A2p72, streams[k].substream.g2, streams[k].substream.g2, mrg31k3p_M2);
                           ^~~~~~~~~~~~~~~~~~~
./include/clRNG/./private/modular.c.h:79:44: note: passing argument to parameter 'A' here
static void modMatVec (MODULAR_NUMBER_TYPE A[N][N], MODULAR_NUMBER_TYPE s[N], MODULAR_NUMBER_TYPE v[N], MODULAR_NUMBER_TYPE m)
                                           ^
========================================

========================================
In file included from 10:3:
In file included from ./include/clRNG/mrg32k3a.clh:156:
./include/clRNG/private/mrg32k3a.c.h:213:13: error: passing '__constant cl_ulong (*)[3]' to parameter of type 'cl_ulong __private (*)[3]' changes address space of pointer
                modMatVec(clrngMrg32k3a_A1p76, streams[k].substream.g1, streams[k].substream.g1, Mrg32k3a_M1);
                          ^~~~~~~~~~~~~~~~~~~
./include/clRNG/./private/modular.c.h:79:44: note: passing argument to parameter 'A' here
static void modMatVec (MODULAR_NUMBER_TYPE A[N][N], MODULAR_NUMBER_TYPE s[N], MODULAR_NUMBER_TYPE v[N], MODULAR_NUMBER_TYPE m)
                                           ^
In file included from 10:3:
In file included from ./include/clRNG/mrg32k3a.clh:156:
./include/clRNG/private/mrg32k3a.c.h:214:13: error: passing '__constant cl_ulong (*)[3]' to parameter of type 'cl_ulong __private (*)[3]' changes address space of pointer
                modMatVec(clrngMrg32k3a_A2p76, streams[k].substream.g2, streams[k].substream.g2, Mrg32k3a_M2);
                          ^~~~~~~~~~~~~~~~~~~
./include/clRNG/./private/modular.c.h:79:44: note: passing argument to parameter 'A' here
static void modMatVec (MODULAR_NUMBER_TYPE A[N][N], MODULAR_NUMBER_TYPE s[N], MODULAR_NUMBER_TYPE v[N], MODULAR_NUMBER_TYPE m)

========================================
```